### PR TITLE
HipChat announcement file is now optional

### DIFF
--- a/src/main/java/no/finntech/maven/notifications/HipChat.java
+++ b/src/main/java/no/finntech/maven/notifications/HipChat.java
@@ -59,7 +59,6 @@ public final class HipChat extends AbstractNotificationMojo {
      * The "announcement" file. Contents are sent as a yammer message.
      */
     @Parameter(
-            defaultValue = "${project.build.directory}/announcement/hipchat-announcement.vm",
             property = "hipchat.announcement",
             required = false)
     private File hipchatAnnouncement;

--- a/src/main/java/no/finntech/maven/notifications/HipChat.java
+++ b/src/main/java/no/finntech/maven/notifications/HipChat.java
@@ -61,9 +61,8 @@ public final class HipChat extends AbstractNotificationMojo {
     @Parameter(
             defaultValue = "${project.build.directory}/announcement/hipchat-announcement.vm",
             property = "hipchat.announcement",
-            required = true)
+            required = false)
     private File hipchatAnnouncement;
-
 
     @Override
     protected void executeImpl() throws MojoExecutionException {
@@ -75,22 +74,33 @@ public final class HipChat extends AbstractNotificationMojo {
             throw new MojoExecutionException("\nhipchatMessage isn't defined.");
         }
 
-        if(!hipchatAnnouncement.exists()) {
-            throw new MojoExecutionException('\n' + hipchatAnnouncement.getAbsolutePath() + " doesn't exist.");
-        }
-
-
         final StringBuilder msg = new StringBuilder(hipchatMessage);
-        try {
-            msg.append("\n").append(new String(Files.readAllBytes(hipchatAnnouncement.toPath()), Charset.forName("UTF-8")));
-        } catch (IOException e) {
-            msg.append("failed to add release announcement. Due to: ").append(e.getMessage());
-        }
+        addAnnouncementFileIfSet(msg);
 
         com.github.hipchat.api.HipChat chat = new com.github.hipchat.api.HipChat(hipchatToken);
         for(String room : hipchatRooms.split(",")) {
             getLog().info("Posting announcement to hipchat (" + room + ')');
             chat.getRoom(room).sendMessage(msg.toString(), UserId.create(hipchatFrom, hipchatFrom), true, Message.Color.PURPLE);
         }
+    }
+
+    void addAnnouncementFileIfSet(StringBuilder msg) throws MojoExecutionException {
+
+        if (hipchatAnnouncement != null) {
+            if (!hipchatAnnouncement.exists()) {
+                throw new MojoExecutionException('\n' + hipchatAnnouncement.getAbsolutePath() + " doesn't exist.");
+            }
+            try {
+                msg.append("\n").append(new String(Files.readAllBytes(hipchatAnnouncement.toPath()), Charset
+                    .forName("UTF-8")));
+            } catch (IOException e) {
+                msg.append("failed to add release announcement. Due to: ").append(e.getMessage());
+            }
+        }
+    }
+
+    void setHipchatAnnouncement(File hipchatAnnouncement) {
+
+        this.hipchatAnnouncement = hipchatAnnouncement;
     }
 }

--- a/src/test/java/no/finntech/maven/notifications/HipChatTest.java
+++ b/src/test/java/no/finntech/maven/notifications/HipChatTest.java
@@ -1,0 +1,39 @@
+package no.finntech.maven.notifications;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.URISyntaxException;
+
+public class HipChatTest {
+
+    @Test
+    public void adds_nothing_when_no_announcement_file_specified() throws MojoExecutionException {
+        HipChat hipChat = new HipChat();
+        StringBuilder msg = new StringBuilder();
+        hipChat.addAnnouncementFileIfSet(msg);
+        assertEquals(0, msg.length());
+    }
+
+    @Test(expected = MojoExecutionException.class)
+    public void throws_exception_on_missing_file() throws MojoExecutionException {
+        HipChat hipChat = new HipChat();
+        StringBuilder msg = new StringBuilder();
+        hipChat.setHipchatAnnouncement(new File("/some/path/that/does/not/exist"));
+        hipChat.addAnnouncementFileIfSet(msg);
+        assertEquals(0, msg.length());
+    }
+
+    @Test
+    public void adds_announcement_file() throws MojoExecutionException, URISyntaxException {
+        HipChat hipChat = new HipChat();
+        StringBuilder msg = new StringBuilder();
+        hipChat.setHipchatAnnouncement(new File(this.getClass().getClassLoader()
+            .getResource("hipchat-announcement").toURI()));
+        hipChat.addAnnouncementFileIfSet(msg);
+        assertEquals("\ntest success", msg.toString());
+    }
+}

--- a/src/test/resources/hipchat-announcement
+++ b/src/test/resources/hipchat-announcement
@@ -1,0 +1,1 @@
+test success


### PR DESCRIPTION
Something like this, then. I don't like the name `addAnnouncementFileIfSet`, but `executeImpl` has to be protected, and the new functionality put in a separate method in order to make it testable.

Also, I don't have the FINN code style, so there might be some style issues.
